### PR TITLE
feat: add board invite API and shared board access control backend

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -683,7 +683,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",

--- a/backend/src/models/boardModel.js
+++ b/backend/src/models/boardModel.js
@@ -15,14 +15,56 @@ const createBoard = async (board, userId) => {
   }
 };
 
+const isBoardOwner = async (boardId, userId) => {
+  const [rows] = await pool.query(
+    'SELECT id FROM boards WHERE id = ? AND user_id = ? LIMIT 1',
+    [boardId, userId]
+  );
+  return rows.length > 0;
+};
+
+const hasBoardAccess = async (boardId, userId) => {
+  const [rows] = await pool.query(
+    `SELECT b.id
+     FROM boards b
+     WHERE b.id = ?
+       AND (
+         b.user_id = ?
+         OR EXISTS (
+           SELECT 1 FROM board_members bm
+           WHERE bm.board_id = b.id AND bm.user_id = ?
+         )
+       )
+     LIMIT 1`,
+    [boardId, userId, userId]
+  );
+  return rows.length > 0;
+};
+
+const addBoardMember = async (boardId, memberUserId, createdBy, role = 'member') => {
+  const [result] = await pool.query(
+    `INSERT INTO board_members (board_id, user_id, role, created_by)
+     VALUES (?, ?, ?, ?)
+     ON DUPLICATE KEY UPDATE role = VALUES(role)`,
+    [boardId, memberUserId, role, createdBy]
+  );
+  return result;
+};
+
 const getBoardById = async (id, userId) => {
   try {
     const [rows] = await pool.query(
-      `SELECT boards.*, users.email as owner_email 
+      `SELECT boards.*, users.email as owner_email,
+              CASE WHEN boards.user_id = ? THEN 'owner' ELSE COALESCE(bm.role, 'member') END AS access_role
        FROM boards 
        JOIN users ON boards.user_id = users.id
-       WHERE boards.id = ? AND boards.user_id = ?`,
-      [id, userId]
+       LEFT JOIN board_members bm ON bm.board_id = boards.id AND bm.user_id = ?
+       WHERE boards.id = ?
+         AND (
+           boards.user_id = ?
+           OR bm.user_id = ?
+         )`,
+      [userId, userId, id, userId, userId]
     );
     
     console.log('Query Result:', rows); // Add debug log
@@ -41,12 +83,20 @@ const getBoardById = async (id, userId) => {
 const getAllBoards = async (userId) => {
   try {
     const [rows] = await pool.query(
-      `SELECT boards.*, COUNT(tasks.id) AS task_count 
+      `SELECT boards.*,
+              users.email AS owner_email,
+              CASE WHEN boards.user_id = ? THEN 'owner' ELSE COALESCE(bm.role, 'member') END AS access_role,
+              (
+                SELECT COUNT(*)
+                FROM tasks
+                WHERE tasks.board_id = boards.id
+              ) AS task_count
        FROM boards 
-       LEFT JOIN tasks ON boards.id = tasks.board_id
-       WHERE boards.user_id = ?
-       GROUP BY boards.id`,
-      [userId]
+       JOIN users ON boards.user_id = users.id
+       LEFT JOIN board_members bm ON bm.board_id = boards.id AND bm.user_id = ?
+       WHERE boards.user_id = ? OR bm.user_id = ?
+       GROUP BY boards.id, users.email, bm.role`,
+      [userId, userId, userId, userId]
     );
     return rows;
   } catch (error) {
@@ -71,6 +121,7 @@ const updateBoard = async (id, board) => {
 
 const deleteBoard = async (id) => {
   try {
+    await pool.query('DELETE FROM board_members WHERE board_id = ?', [id]);
     await pool.query('DELETE FROM tasks WHERE board_id = ?', [id]);
     const [result] = await pool.query('DELETE FROM boards WHERE id = ?', [id]);
     return result;
@@ -82,6 +133,9 @@ const deleteBoard = async (id) => {
 
 module.exports = {
   createBoard,
+  isBoardOwner,
+  hasBoardAccess,
+  addBoardMember,
   getBoardById,
   getAllBoards,
   updateBoard,

--- a/backend/src/routes/boardRoutes.js
+++ b/backend/src/routes/boardRoutes.js
@@ -6,7 +6,8 @@ const {
   getBoards,
   getBoard,
   updateBoard,
-  deleteBoard
+  deleteBoard,
+  inviteUserToBoard
 } = require('../controllers/boardController');
 const { authenticate } = require('../middleware/authMiddleware');
 
@@ -17,6 +18,7 @@ router.get('/', getBoards);
 router.get('/:id', getBoard);
 router.put('/:id', updateBoard);
 router.delete('/:id', deleteBoard);
+router.post('/:id/invite', inviteUserToBoard);
 
 module.exports = router;
 

--- a/backend/src/utils/dbSetup.js
+++ b/backend/src/utils/dbSetup.js
@@ -69,6 +69,18 @@ const setupDatabase = async () => {
   );
 
   await ensureTable(
+    'CREATE TABLE IF NOT EXISTS board_members (\n' +
+      'id INT AUTO_INCREMENT PRIMARY KEY,\n' +
+      'board_id INT NOT NULL,\n' +
+      'user_id INT NOT NULL,\n' +
+      'role VARCHAR(20) NOT NULL DEFAULT "member",\n' +
+      'created_by INT NOT NULL,\n' +
+      'created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,\n' +
+      'UNIQUE KEY uniq_board_user (board_id, user_id)\n' +
+    ')'
+  );
+
+  await ensureTable(
     'CREATE TABLE IF NOT EXISTS faq_questions (\n' +
       'id INT AUTO_INCREMENT PRIMARY KEY,\n' +
       'user_id INT NULL,\n' +

--- a/frontend/src/pages/contact.jsx
+++ b/frontend/src/pages/contact.jsx
@@ -85,35 +85,6 @@ const Contact = () => {
     }
   ];
 
-  const faqItems = [
-    {
-      question: 'WHAT IS TASKFLOW?',
-      answer: `TaskFlow is a brutalist task management tool designed for teams who value simplicity and clarity. We strip away complexity and focus on what actually matters—getting work done.`
-    },
-    {
-      question: 'HOW MUCH DOES TASKFLOW COST?',
-      answer: `Our pricing is transparent and simple. Start free with unlimited tasks, upgrade to Pro for advanced features at $29/month. No hidden fees, no surprise charges.`
-    },
-    {
-      question: 'CAN I IMPORT MY TASKS?',
-      answer: `Yes! We support imports from most popular task management tools. Just reach out to our support team and we'll help you migrate your data quickly and safely.`
-    },
-    {
-      question: 'IS MY DATA SECURE?',
-      answer: `We take security seriously. All data is encrypted in transit and at rest. We maintain SOC 2 compliance and conduct regular security audits to protect your information.`
-    },
-    {
-      question: 'WHAT ABOUT INTEGRATIONS?',
-      answer: `TaskFlow integrates with Slack, Microsoft Teams, GitHub, GitLab, and more. We're always adding new integrations based on user requests.`
-    },
-    {
-      question: 'IS THERE A FREE TRIAL?',
-      answer: `Absolutely. Sign up for free and get 14 days of full access to all Pro features. No credit card required.`
-    }
-  ];
-
-  const [expandedFaq, setExpandedFaq] = useState(null);
-
   return (
     <div className="contact-container">
       <Navbar />
@@ -235,38 +206,6 @@ const Contact = () => {
                 </div>
               )}
             </form>
-          </div>
-        </div>
-      </section>
-
-      {/* FAQ Section */}
-      <section className="faq-section">
-        <div className="container">
-          <div className="form-header">
-            <h2 className="section-title">FREQUENTLY ASKED</h2>
-            <div className="section-line"></div>
-          </div>
-
-          <div className="faq-grid">
-            {faqItems.map((item, index) => (
-              <div
-                key={index}
-                className={`faq-item ${expandedFaq === index ? 'expanded' : ''}`}
-              >
-                <button
-                  className="faq-question"
-                  onClick={() => setExpandedFaq(expandedFaq === index ? null : index)}
-                >
-                  <span>{item.question}</span>
-                  <span className="faq-toggle">{expandedFaq === index ? '−' : '+'}</span>
-                </button>
-                {expandedFaq === index && (
-                  <div className="faq-answer">
-                    <p>{item.answer}</p>
-                  </div>
-                )}
-              </div>
-            ))}
           </div>
         </div>
       </section>

--- a/frontend/src/pages/dashboard.jsx
+++ b/frontend/src/pages/dashboard.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Navigate } from 'react-router-dom';
 import { useAuth } from '../context/authContext';
-import { Container, Row, Col, Card, Alert, Modal, Form, Button } from 'react-bootstrap';
+import { Container, Card, Alert, Modal, Form, Button } from 'react-bootstrap';
 import Navbar from '../components/navbar';
 import TaskList from '../components/taskList';
 import Sidebar from '../components/sidebar';
@@ -29,6 +29,12 @@ const Dashboard = () => {
     priority: 'medium'
   });
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  const normalizeStatus = (status) =>
+    String(status || 'pending').trim().toLowerCase().replace(/\s+/g, '-');
+
+  const countByStatus = (status) =>
+    tasks.filter((task) => normalizeStatus(task.status) === status).length;
 
   const toggleSidebar = () => setIsSidebarOpen(v => !v);
 
@@ -265,32 +271,40 @@ const Dashboard = () => {
 
           {activeBoard ? (
             <>
-              <Row className="stats-grid">
-                <Col xl={3} md={6}>
+              <div className="dashboard-stats-grid">
+                <div className="dashboard-stats-item">
                   <StatsCard 
                     title="Total Tasks"
                     value={tasks.length}
                     variant="primary"
                     icon="fa-clipboard-list"
                   />
-                </Col>
-                <Col xl={3} md={6}>
+                </div>
+                <div className="dashboard-stats-item">
                   <StatsCard 
                     title="Pending Tasks"
-                    value={tasks.filter(t => t.status === 'pending').length}
+                    value={countByStatus('pending')}
                     variant="warning"
                     icon="fa-clock"
                   />
-                </Col>
-                <Col xl={3} md={6}>
+                </div>
+                <div className="dashboard-stats-item">
+                  <StatsCard 
+                    title="In Progress Tasks"
+                    value={countByStatus('in-progress')}
+                    variant="info"
+                    icon="fa-spinner"
+                  />
+                </div>
+                <div className="dashboard-stats-item">
                   <StatsCard 
                     title="Completed Tasks"
-                    value={tasks.filter(t => t.status === 'completed').length}
+                    value={countByStatus('completed')}
                     variant="success"
                     icon="fa-check-circle"
                   />
-                </Col>
-              </Row>
+                </div>
+              </div>
 
               <Card className="task-list-card">
                 <Card.Header className="task-list-header">

--- a/frontend/src/pages/features.jsx
+++ b/frontend/src/pages/features.jsx
@@ -1,5 +1,5 @@
 // features.jsx - LIGHT BRUTALIST
-import React, { useState } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import Navbar from '../components/navbar';
 import { 
@@ -71,28 +71,7 @@ const integrations = [
   { name: 'API', icon: <TbApi /> }
 ];
 
-const faq = [
-  { 
-    q: 'Can I invite team members?', 
-    a: 'Yes, invite unlimited team members with role-based permissions. Share via email or link.'
-  },
-  { 
-    q: 'Does it integrate with other tools?', 
-    a: 'Yes, native integrations with 20+ tools plus webhook support and custom API.'
-  },
-  { 
-    q: 'Is there offline support?', 
-    a: 'Yes, work offline and sync automatically when you reconnect.'
-  },
-  { 
-    q: 'How secure is my data?', 
-    a: 'AES-256 encryption, TLS 1.3, regular security audits, and compliance with privacy standards.'
-  }
-];
-
 const Features = () => {
-  const [openFaq, setOpenFaq] = useState(null);
-
   return (
     <div className="features-simple">
       <Navbar />
@@ -154,34 +133,6 @@ const Features = () => {
                   {integration.icon}
                 </span>
                 {integration.name}
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* FAQ */}
-      <section className="faq">
-        <div className="container">
-          <h2 className="section-title text-center mb-5">FAQ</h2>
-          <div className="faq-list">
-            {faq.map((item, idx) => (
-              <div key={idx} className="faq-item">
-                <button 
-                  className="faq-q" 
-                  onClick={() => setOpenFaq(openFaq === idx ? null : idx)}
-                  aria-expanded={openFaq === idx}
-                >
-                  {item.q}
-                  <span className="chev">
-                    {openFaq === idx ? '−' : '+'}
-                  </span>
-                </button>
-                {openFaq === idx && (
-                  <div className="faq-a">
-                    {item.a}
-                  </div>
-                )}
               </div>
             ))}
           </div>

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -234,11 +234,15 @@
 }
 
 /* Stats */
-.stats-grid {
+.dashboard-stats-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 1.25rem;
   margin-bottom: 2.5rem;
+}
+
+.dashboard-stats-item {
+  min-width: 0;
 }
 
 .stats-card {
@@ -555,7 +559,7 @@
     gap: 1rem;
   }
 
-  .stats-grid,
+  .dashboard-stats-grid,
   .tasks-board {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
feat(boards): add user invite endpoint and board membership model
add board_members table setup
add POST /api/boards/:id/invite (owner-only, invite by email)
allow invited members to access shared boards and tasks
update board list/get queries to include shared boards and access role