### PR TITLE
feat(frontend): add task assignee UI and connect board users API

### DIFF
--- a/backend/src/controllers/boardController.js
+++ b/backend/src/controllers/boardController.js
@@ -56,6 +56,25 @@ exports.getBoard = async (req, res) => {
   }
 };
 
+exports.getBoardUsers = async (req, res) => {
+  try {
+    const boardId = Number(req.params.id);
+    if (!boardId) {
+      return res.status(400).json({ error: 'Board ID is required' });
+    }
+
+    const users = await Board.getBoardUsers(boardId, req.userId);
+    if (users === null) {
+      return res.status(404).json({ error: 'Board not found' });
+    }
+
+    return res.status(200).json(users);
+  } catch (error) {
+    console.error('Error fetching board users:', error);
+    return res.status(500).json({ error: 'Failed to fetch board users' });
+  }
+};
+
 exports.updateBoard = async (req, res) => {
   try {
     console.log('updateBoard called with params:', req.params, 'body:', req.body, 'userId:', req.userId);

--- a/backend/src/controllers/taskController.js
+++ b/backend/src/controllers/taskController.js
@@ -223,7 +223,9 @@ exports.updateTask = async (req, res) => {
       return res.status(400).json({ error: parseError.message });
     }
 
-    if (assignee.provided) {
+    const isAssigneeChanging = assignee.provided && assignee.value !== currentAssignee;
+
+    if (isAssigneeChanging) {
       if (!isBoardOwner) {
         if (assignee.value === null) {
           return res.status(403).json({ error: 'Only board owner can unassign tasks' });
@@ -245,6 +247,8 @@ exports.updateTask = async (req, res) => {
         }
       }
 
+      req.body.assignee_user_id = assignee.value;
+    } else if (assignee.provided) {
       req.body.assignee_user_id = assignee.value;
     }
 

--- a/backend/src/routes/boardRoutes.js
+++ b/backend/src/routes/boardRoutes.js
@@ -7,6 +7,7 @@ const {
   getMyInvitations,
   respondToInvitation,
   getBoard,
+  getBoardUsers,
   updateBoard,
   deleteBoard,
   inviteUserToBoard
@@ -20,6 +21,7 @@ router.get('/', getBoards);
 router.get('/invitations', getMyInvitations);
 router.post('/invitations/:invitationId/respond', respondToInvitation);
 router.get('/:id', getBoard);
+router.get('/:id/users', getBoardUsers);
 router.put('/:id', updateBoard);
 router.delete('/:id', deleteBoard);
 router.post('/:id/invite', inviteUserToBoard);
@@ -94,6 +96,35 @@ module.exports = router;
  *     responses:
  *       200:
  *         description: Board details
+ *       401:
+ *         description: Unauthorized
+ *       404:
+ *         description: Board not found
+ *       500:
+ *         description: Server error
+ *
+ * /api/boards/{id}/users:
+ *   get:
+ *     summary: Get users that can be assigned tasks on a board
+ *     tags: [Boards]
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: Board ID
+ *     responses:
+ *       200:
+ *         description: Users on board (owner and members)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/BoardUser'
  *       401:
  *         description: Unauthorized
  *       404:

--- a/backend/swagger-config.js
+++ b/backend/swagger-config.js
@@ -84,6 +84,14 @@ const options = {
             email: { type: 'string', format: 'email', example: 'user@example.com' },
             password: { type: 'string', example: 'password123' }
           }
+        },
+        BoardUser: {
+          type: 'object',
+          properties: {
+            id: { type: 'integer', example: 7 },
+            email: { type: 'string', format: 'email', example: 'member@example.com' },
+            role: { type: 'string', enum: ['owner', 'member'], example: 'member' }
+          }
         }
       }
     },

--- a/frontend/src/components/taskList.jsx
+++ b/frontend/src/components/taskList.jsx
@@ -21,7 +21,7 @@ const TaskList = ({ tasks, loading, error, onEditTask, onDeleteTask, onToggleSta
   }
 
   const getPriorityColor = (priority) => {
-    switch (priority.toLowerCase()) {
+    switch (String(priority || 'medium').toLowerCase()) {
       case 'high': return '#dc3545';
       case 'medium': return '#ffc107';
       case 'low': return '#0dcaf0';
@@ -30,7 +30,7 @@ const TaskList = ({ tasks, loading, error, onEditTask, onDeleteTask, onToggleSta
   };
 
   const getStatusIcon = (status) => {
-    switch (status.toLowerCase()) {
+    switch (String(status || 'pending').toLowerCase()) {
       case 'completed': 
         return <FiCheckCircle style={{ color: '#198754' }} />;
       case 'in-progress': 
@@ -42,11 +42,11 @@ const TaskList = ({ tasks, loading, error, onEditTask, onDeleteTask, onToggleSta
   };
 
   const getStatusLabel = (status) => {
-    switch (status.toLowerCase()) {
+    switch (String(status || 'pending').toLowerCase()) {
       case 'in-progress':
         return 'In Progress';
       default:
-        return status.charAt(0).toUpperCase() + status.slice(1);
+        return String(status || 'pending').charAt(0).toUpperCase() + String(status || 'pending').slice(1);
     }
   };
 
@@ -127,6 +127,10 @@ const TaskList = ({ tasks, loading, error, onEditTask, onDeleteTask, onToggleSta
                     <p className="task-description">{task.description}</p>
                   )}
 
+                  <div className="task-assignee">
+                    <strong>Assignee:</strong> {task.assignee_email || 'Unassigned'}
+                  </div>
+
                   <div className="task-footer">
                     <button
                       className={`badge status-badge ${normalizeStatus(task.status)}`}
@@ -141,7 +145,7 @@ const TaskList = ({ tasks, loading, error, onEditTask, onDeleteTask, onToggleSta
                         marginLeft: '0.5rem'
                       }}
                     >
-                      {task.priority.charAt(0).toUpperCase() + task.priority.slice(1)} Priority
+                      {String(task.priority || 'medium').charAt(0).toUpperCase() + String(task.priority || 'medium').slice(1)} Priority
                     </Badge>
                   </div>
                 </div>

--- a/frontend/src/services/boards.jsx
+++ b/frontend/src/services/boards.jsx
@@ -115,3 +115,19 @@ export const respondToBoardInvitation = async (invitationId, action) => {
     throw new Error(serverMsg);
   }
 };
+
+export const fetchBoardUsers = async (boardId) => {
+  try {
+    const response = await axios.get(`${API_URL}/api/boards/${boardId}/users`, {
+      headers: getAuthHeader()
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching board users:', error);
+    if (error.response?.status === 401) {
+      handleUnauthorized();
+    }
+    const serverMsg = error.response?.data?.error || error.message || 'Failed to fetch board users';
+    throw new Error(serverMsg);
+  }
+};


### PR DESCRIPTION
feat(frontend): add task assignee UI and connect board users API

frontend: add Assign To dropdown in create/edit task modals on dashboard
frontend: fetch board users and submit assignee_user_id for task assignment
frontend: display assignee email on task cards
backend: add board users endpoint and swagger docs (BoardUser schema)
fix: allow non-owner assignee to move task status without false 409 when assignee is unchanged
